### PR TITLE
Make PATH cargo default setting and add errors for wrong file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rust Auto Compile is a simple script that runs cargo automatically before you run your game.
 
-It adds 2 settings:
-rust/cargo_path: The path to your cargo executable
+It adds 2 settings:\
+rust/cargo_path: The path to your cargo executable. The default is set to PATH cargo. \
 rust/cargo_manifest: The path to the Cargo.toml of the library you want built.
 
 You need to have those 2 settings set for the plugin to work.

--- a/addons/rust_auto_compile/rust_auto_compile.gd
+++ b/addons/rust_auto_compile/rust_auto_compile.gd
@@ -1,40 +1,85 @@
 @tool
 extends EditorPlugin
 
+var MANIFEST_SETTING = "rust/manifest_path"
+var CARGO_PATH_SETTING = "rust/cargo_path"
+
+func _check_for_settings() -> bool:
+	var cargo_path = ProjectSettings.get_setting("rust/cargo_path")
+	var manifest_path = ProjectSettings.get_setting("rust/manifest_path")
+	
+	if cargo_path == null:
+		push_error(
+				(
+					"The cargo executable is not set. Go to Editor > Editor Settings... > Rust and set Cargo Path to the absolute path to the cargo binary on your system."
+				)
+			)
+		return false
+	
+	if manifest_path == null:
+		push_error(
+				(
+					"The Cargo.toml is not set. Go to Editor > Editor Settings... > Rust and set Manifest Path to the absolute path to the cargo.toml on your system."
+				)
+			)
+		return false
+	
+	# if no cargo or manifest path just skip building the library
+#	Copied from rust_tools <3
+	if cargo_path.contains("/") or cargo_path.contains("\\"):
+		if not FileAccess.file_exists(cargo_path):
+			push_error(
+				(
+					"The configured cargo executable '%s' does not exist. Go to Editor > Editor Settings... > Rust and set Cargo Path to the absolute path to the cargo binary on your system."
+					% [cargo_path]
+				)
+			)
+			
+			return false
+	return true
+
+func _register_settings():
+	if ProjectSettings.get_setting(MANIFEST_SETTING) != null \
+		and ProjectSettings.get_setting(CARGO_PATH_SETTING) != null:
+		
+		return
+	
+	ProjectSettings.set_setting(MANIFEST_SETTING, "")
+	ProjectSettings.set_setting(CARGO_PATH_SETTING, "cargo") #set to value in PATH
+	
+	ProjectSettings.add_property_info({
+		"name": MANIFEST_SETTING,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_GLOBAL_FILE,
+		"hint_string": "*.toml"
+	})
+	
+	ProjectSettings.add_property_info({
+		"name": CARGO_PATH_SETTING,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_GLOBAL_FILE
+	})
+	
+	ProjectSettings.set_as_basic(MANIFEST_SETTING, true)
+	ProjectSettings.set_as_basic(CARGO_PATH_SETTING, true)
+	
+	ProjectSettings.save()
+
 func _enter_tree() -> void:
-	pass
+	_register_settings()
 
 func _enable_plugin() -> void:
-	if ProjectSettings.get_setting("rust/manifest_path") == null:
-		ProjectSettings.set_setting("rust/manifest_path", "")
-		ProjectSettings.set_setting("rust/cargo_path", "")
-		
-		var info_manifest = {
-			"name": "rust/manifest_path",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_GLOBAL_FILE,
-			"hint_string": "*.toml"
-		}
-		var info_cargo = {
-			"name": "rust/cargo_path",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_GLOBAL_FILE,
-		}
-		
-		ProjectSettings.add_property_info(info_manifest)
-		ProjectSettings.add_property_info(info_cargo)
-		ProjectSettings.save()
-	pass
+	_register_settings()
+	
 
 func _build():
 	var output = []
 	var cargo_path = ProjectSettings.get_setting("rust/cargo_path")
 	var manifest_path = ProjectSettings.get_setting("rust/manifest_path")
 	
-	# if no cargo or manifest path just skip building the library
-	if cargo_path == null or manifest_path == null:
-		return true
-
+	if not _check_for_settings():
+		return
+	
 	var exit_code = OS.execute(cargo_path, ["build", "--manifest-path", manifest_path], output, true)
 	if exit_code != 0:
 		for s in output:

--- a/addons/rust_auto_compile/rust_auto_compile.gd
+++ b/addons/rust_auto_compile/rust_auto_compile.gd
@@ -24,7 +24,6 @@ func _check_for_settings() -> bool:
 			)
 		return false
 	
-	# if no cargo or manifest path just skip building the library
 #	Copied from rust_tools <3
 	if cargo_path.contains("/") or cargo_path.contains("\\"):
 		if not FileAccess.file_exists(cargo_path):
@@ -76,7 +75,8 @@ func _build():
 	var output = []
 	var cargo_path = ProjectSettings.get_setting("rust/cargo_path")
 	var manifest_path = ProjectSettings.get_setting("rust/manifest_path")
-	
+
+# 	if no cargo or manifest path just skip building the library
 	if not _check_for_settings():
 		return
 	


### PR DESCRIPTION
Make PATH cargo the default, 
initialize settings on editor start, 
add checks for legit path to files and display readable errors.